### PR TITLE
Fix repost.filename typos for collection and like functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@
                 data.collections.forEach(collection => {
                     //script += `curl -o "${collection.filename}" "${collection.url}"\n`;
                     //This has to be done with yt-dlp because collections are not available for download via the tiktok api
-                    script += `yt-dlp -o "${repost.filename}" "${repost.url}"\n`;
+                    script += `yt-dlp -o "${collection.filename}" "${repost.url}"\n`;
                 });
             }
 
@@ -283,7 +283,7 @@
                 data.likes.forEach(like => {
                     //script += `curl -o "${like.filename}" "${like.url}"\n`;
                     //This has to be done with yt-dlp because likes are not available for download via the tiktok api
-                    script += `yt-dlp -o "${repost.filename}" "${repost.url}"\n`;
+                    script += `yt-dlp -o "${like.filename}" "${repost.url}"\n`;
                 });
             }
 
@@ -316,7 +316,7 @@
                 data.collections.forEach(collection => {
                     //script += `curl -o "${collection.filename}" "${collection.url}"\n`;
                     //This has to be done with yt-dlp because collections are not available for download via the tiktok api
-                    script += `yt-dlp -o "${repost.filename}" "${repost.url}"\n`;
+                    script += `yt-dlp -o "${collection.filename}" "${repost.url}"\n`;
                 });
             }
 
@@ -325,7 +325,7 @@
                 data.likes.forEach(like => {
                     //script += `curl -o "${like.filename}" "${like.url}"\n`;
                     //This has to be done with yt-dlp because likes are not available for download via the tiktok api
-                    script += `yt-dlp -o "${repost.filename}" "${repost.url}"\n`;
+                    script += `yt-dlp -o "${like.filename}" "${repost.url}"\n`;
                 });
             }
 

--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
             ret = likes.map(like => {
                 const date = like.date.replace(/[^0-9]/g, '-');
                 return {
-                    url: like.Link,
+                    url: like.link,
                     filename: `like_${date}.mp4`
                 };
             });


### PR DESCRIPTION
`repost.filename` var was used in several places where `collection.filename` or `like.filename` should have been used, causing errors.